### PR TITLE
Explicitly specify 'zicsr' extension when building. Use stm32loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OBJDUMP := $(CROSS)objdump
 READELF := $(CROSS)readelf
 
 # MCU and board specific variables
-ARCH ?= rv32imac
+ARCH ?= rv32imac_zicsr
 EMU ?= elf32lriscv
 MCU ?= gd32vf103
 BOARD ?= longan-nano-lite

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Development progress has been logged regularly in the [devlogs](https://aw.githu
 
 The quickest way to get started is to download and flash one of the firmware binaries listed below:.
 
-* [fiveforths-longan-nano-lite.bin](https://github.com/aw/fiveforths/releases/download/v0.4/fiveforths-longan-nano-lite.bin) (64K Flash, 20K RAM)
-* [fiveforths-longan-nano.bin](https://github.com/aw/fiveforths/releases/download/v0.4/fiveforths-longan-nano.bin) (128K Flash, 32K RAM)
+* [fiveforths-longan-nano-lite.bin](https://github.com/aw/fiveforths/releases/download/v0.5/fiveforths-longan-nano-lite.bin) (64K Flash, 20K RAM)
+* [fiveforths-longan-nano.bin](https://github.com/aw/fiveforths/releases/download/v0.5/fiveforths-longan-nano.bin) (128K Flash, 32K RAM)
 
 See the [TUTORIALS](docs/TUTORIALS.md) for detailed download and flashing information.
 
@@ -44,6 +44,11 @@ See the [TUTORIALS](docs/TUTORIALS.md) for detailed download and flashing inform
 Please create a pull-request or [open an issue](https://github.com/aw/picolisp-kv/issues/new) on GitHub.
 
 # Changelog
+
+## 0.5 (TBD)
+
+  * Fix issue #19 - Error building without zicsr extension
+  * Fix issue #20 - Specify `stm32loader` instead of `dfu-util` in docs
 
 ## 0.4 (2023-01-23)
 

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -97,7 +97,7 @@ Accessing _FiveForths_ through the terminal should look similar to this:
 $ pyserial-miniterm --eol LF /dev/ttyUSB0 115200
 --- Miniterm on /dev/ttyUSB0  115200,8,N,1 ---
 --- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
-FiveForths v0.4, Copyright (c) 2021~ Alexander Williams, https://a1w.ca
+FiveForths v0.5, Copyright (c) 2021~ Alexander Williams, https://a1w.ca
 
 ```
 

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -20,7 +20,7 @@ This document provides a quick guide to get started using _FiveForths_.
 
 * Linux (tested on Debian bullseye) with _RISC-V_ cross-compilation binaries installed
 * 32-bit GD32VF103 microcontroller
-* USB cable for flashing firmware (using `dfu-util`), or Serial/USB UART (`PA9`, `PA10`) pins
+* USB cable for flashing firmware (using `stm32loader`), or Serial/USB UART (`PA9`, `PA10`) pins
 * Serial/USB UART connected to JTAG (`PA13`, `PA14`, `PA15`, `PB3`) pins for debugging
 * Manually built `openocd` and `gdb` installed in `/opt/riscv/` for debugging
 
@@ -54,8 +54,8 @@ It is possible to download a pre-built firmware binary, or build the firmware ma
 
 Download one of the firmware binaries from the [releases page](https://github.com/aw/fiveforths/releases).
 
-* [fiveforths-longan-nano-lite.bin](https://github.com/aw/fiveforths/releases/download/v0.4/fiveforths-longan-nano-lite.bin) (64K Flash, 20K RAM)
-* [fiveforths-longan-nano.bin](https://github.com/aw/fiveforths/releases/download/v0.4/fiveforths-longan-nano.bin) (128K Flash, 32K RAM)
+* [fiveforths-longan-nano-lite.bin](https://github.com/aw/fiveforths/releases/download/v0.5/fiveforths-longan-nano-lite.bin) (64K Flash, 20K RAM)
+* [fiveforths-longan-nano.bin](https://github.com/aw/fiveforths/releases/download/v0.5/fiveforths-longan-nano.bin) (128K Flash, 32K RAM)
 
 ### Build it
 
@@ -78,7 +78,7 @@ Finally, build the firmware and debug files with `make`. The output should look 
 
 ```
 $ make
-/usr/bin/riscv64-unknown-elf-as -g -march=rv32imac -I src/boards/longan-nano-lite -I src/mcus/gd32vf103 -I src -o fiveforths.o fiveforths.s
+/usr/bin/riscv64-unknown-elf-as -g -march=rv32imac_zicsr -I src/boards/longan-nano-lite -I src/mcus/gd32vf103 -I src -o fiveforths.o fiveforths.s
 /usr/bin/riscv64-unknown-elf-ld -m elf32lriscv -T src/boards/longan-nano-lite/linker.ld -o fiveforths.elf fiveforths.o
 /usr/bin/riscv64-unknown-elf-objcopy -O binary fiveforths.elf fiveforths.bin
 /usr/bin/riscv64-unknown-elf-objcopy -O ihex fiveforths.elf fiveforths.hex
@@ -87,7 +87,7 @@ $ make
 
 Additional build options are explained in the [HOWTO](HOWTO.md) section.
 
-The firmware file is called `fiveforths.bin` and is **approximately 2.5 KBytes** as of _release v0.4_ since _January 23, 2023_.
+The firmware file is called `fiveforths.bin` and is **approximately 2.5 KBytes**.
 
 ### Flash it
 

--- a/src/06-initialization.s
+++ b/src/06-initialization.s
@@ -73,4 +73,4 @@ tib_zerofill:
 tib_done:
     j interpreter_start # jump to the main interpreter REPL
 
-msg_boot: .ascii "FiveForths v0.4, Copyright (c) 2021~ Alexander Williams, https://a1w.ca \n\n"
+msg_boot: .ascii "FiveForths v0.5, Copyright (c) 2021~ Alexander Williams, https://a1w.ca \n\n"


### PR DESCRIPTION
This PR fixes the issue from #19 where newer versions of gcc/binutils **require** specifying the `zicsr` extension if using the CSR extensions. It also removes the mention of `dfu-util` in the docs as noted in issue #20, to avoid confusion.